### PR TITLE
dele: 記事詳細画面の下部<PostTags>削除

### DIFF
--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -105,7 +105,6 @@ if (post.FeaturedImage && post.FeaturedImage.Url) {
       <PostTags post={post} />
       <PostTitle post={post} enableLink={false} />
       <PostBody blocks={blocks} />
-      <PostTags post={post} />
 
       <footer>
         <PostRelativeLink prevPost={prevPost} nextPost={nextPost} />


### PR DESCRIPTION
- https://www.notion.so/Tag-addb58274f1546058b163e400b52566b?pvs=4
- prev, post記事のslugと近くて紛らわしいため
- また、ここに現在ページのタグは表示するメリットが感じられない。